### PR TITLE
Scan all manifest registries, not just registry.ollama.ai

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,13 +36,13 @@ func LoadConfig() (*Config, error) {
 		}
 		// Use Windows conventions.
 		configDir = filepath.Join(appData, "ollama-sync")
-		defaultManifest = filepath.Join(appData, "Ollama", "models", "manifests", "registry.ollama.ai")
+		defaultManifest = filepath.Join(appData, "Ollama", "models", "manifests")
 		defaultBlob = filepath.Join(appData, "Ollama", "models", "blobs")
 		defaultDest = filepath.Join(localAppData, "lm-studio", "ollama")
 	} else {
 		// POSIX-style defaults.
 		configDir = filepath.Join(homeDir, ".config", "ollama-sync")
-		defaultManifest = filepath.Join(homeDir, ".ollama", "models", "manifests", "registry.ollama.ai")
+		defaultManifest = filepath.Join(homeDir, ".ollama", "models", "manifests")
 		defaultBlob = filepath.Join(homeDir, ".ollama", "models", "blobs")
 		defaultDest = filepath.Join(homeDir, ".cache", "lm-studio", "models", "ollama")
 	}

--- a/internal/manifest/process.go
+++ b/internal/manifest/process.go
@@ -52,6 +52,7 @@ func ProcessManifest(manifestPath, blobDir string, destDirs []string, logger *lo
 	}
 
 	modelName := filepath.Base(filepath.Dir(manifestPath))
+	tag := filepath.Base(manifestPath) // e.g., "q8_0" - the Ollama tag
 
 	for _, destDir := range destDirs {
 		if err := os.MkdirAll(destDir, 0755); err != nil {
@@ -63,8 +64,13 @@ func ProcessManifest(manifestPath, blobDir string, destDirs []string, logger *lo
 			return fmt.Errorf("failed to create model directory %s: %w", modelDir, err)
 		}
 
+		fileType := modelConfig.FileType
+		if fileType == "unknown" || fileType == "" {
+			fileType = tag // Use Ollama tag instead
+		}
+
 		symlinkName := filepath.Join(modelDir,
-			fmt.Sprintf("%s-%s-%s.%s", modelName, modelConfig.ModelType, modelConfig.FileType, modelConfig.ModelFormat))
+			fmt.Sprintf("%s-%s-%s.%s", modelName, modelConfig.ModelType, fileType, modelConfig.ModelFormat))
 
 		if _, err := os.Lstat(symlinkName); err == nil {
 			if err := os.Remove(symlinkName); err != nil {


### PR DESCRIPTION
Previously the manifest directory defaulted to only scanning .ollama/models/manifests/registry.ollama.ai, which missed models pulled from Hugging Face that are stored under hf.co/ subdirectory.

Now scans the parent manifests directory to find all registries.